### PR TITLE
same priorities for url match and generate

### DIFF
--- a/Router.php
+++ b/Router.php
@@ -57,7 +57,9 @@ class Router {
 
         if(isset($args['name'])) {
             $route->setName($args['name']);
-            $this->namedRoutes[$route->getName()] = $route;
+            if (!isset($this->namedRoutes[$route->getName()])) {
+                $this->namedRoutes[$route->getName()] = $route;
+            }
         }
 
         $this->routes[] = $route;


### PR DESCRIPTION
Hi,

At the moment, there are different priorities on routes when matching the current request or generating an url:

```
$router->map('/aaa',    'target1', array('name'=>'aaa'));
$router->map('/aaa',    'target2', array('name'=>'-b-'));
$router->map('/other',  'target2', array('name'=>'aaa'));

var_dump($router->matchCurrentRequest());
var_dump($router->generate('aaa'));
```

When you go to /aaa, the first target (target1) will be picked, but when you will generate an url with the name 'aaa', the last with this name will be picked (resulting to /other).
Sometimes you will want to overwrite some routes, there you can't because of different precedences.
I propose a simple isset() to enable overwrite (a "declare before" overwrite)

let me know what you think, thank you. – niahoo

Results to:

```
object(Route)#38 (7) {
  ["url":"Route":private]=>
  string(13) "/toulmuz/aaa/"
  ["methods":"Route":private]=>
  array(4) {
    [0]=>
    string(3) "GET"
    [1]=>
    string(4) "POST"
    [2]=>
    string(3) "PUT"
    [3]=>
    string(6) "DELETE"
  }
  ["name":"Route":private]=>
  string(3) "aaa"
  ["filters":"Route":private]=>
  array(0) {
  }
  ["params":"Route":private]=>
  array(0) {
  }
  ["target":"Route":private]=>
  string(7) "target1"
  ["parameters"]=>
  array(0) {
  }
}
string(15) "/toulmuz/other/"
```
