### PR TITLE
Filename is not printed on screen when loading config from file.

### DIFF
--- a/src/PHPRouter/Config.php
+++ b/src/PHPRouter/Config.php
@@ -7,7 +7,6 @@ class Config
 {
     public static function loadFromFile($yamlFile)
     {
-        echo $yamlFile;
         try {
             $value = Yaml::parse(file_get_contents($yamlFile));
         } catch (\Exception $e) {


### PR DESCRIPTION
Think this was not wanted.
