### PR TITLE
Allowed passing of parameters

### DIFF
--- a/src/PHPRouter/Route.php
+++ b/src/PHPRouter/Route.php
@@ -129,6 +129,6 @@ class Route
     {
         $action = explode('::', $this->_config['_controller']);
         $instance = new $action[0];
-        $instance->$action[1]();
+        call_user_func_array(array($instance, $action[1]), $this->_parameters);
     }
 }


### PR DESCRIPTION
Allowed the passing of parameters into the controllers instance method.

Before my change, if I defined a filter for a route (eg. '/users/:id'), then $id would not be a variable I could use within the my controller's method (eg. function user ($id) { ... } ).
