### PR TITLE
Added parameters by name

### DIFF
--- a/src/PHPRouter/Route.php
+++ b/src/PHPRouter/Route.php
@@ -27,7 +27,6 @@ class Route
 
     /**
      * Accepted HTTP methods for this route.
-     *
      * @var string[]
      */
     private $methods = array('GET', 'POST', 'PUT', 'DELETE');
@@ -56,6 +55,13 @@ class Route
      */
     private $parameters = array();
 
+    /**
+     * Set named parameters to target method
+     * @example [ [0] => [ ["link_id"] => "12312" ] ]
+     * @var bool
+     */
+    private $parametersByName;
+    
     /**
      * @var array
      */
@@ -120,9 +126,14 @@ class Route
         $this->name = (string)$name;
     }
 
-    public function setFilters(array $filters)
+    public function setFilters(array $filters, $parametersByName = false)
     {
         $this->filters = $filters;
+        
+        if($parametersByName) {
+          $this->parametersByName = true;
+        }
+        
     }
 
     public function getRegex()
@@ -143,7 +154,7 @@ class Route
     {
         return $this->parameters;
     }
-
+    
     public function setParameters(array $parameters)
     {
         $this->parameters = $parameters;
@@ -153,6 +164,11 @@ class Route
     {
         $action = explode('::', $this->config['_controller']);
         $instance = new $action[0];
+        
+        if($this->parametersByName) {
+          $this->parameters = array($this->parameters);
+        }
+        
         call_user_func_array(array($instance, $action[1]), $this->parameters);
     }
 }

--- a/tests/Fixtures/SomeController.php
+++ b/tests/Fixtures/SomeController.php
@@ -22,4 +22,5 @@ final class SomeController
     public function users_create() {}
     public function indexAction() {}
     public function user() {}
+    public function page() { var_dump(func_get_args()); }
 }

--- a/tests/PHPRouter/RouterTest.php
+++ b/tests/PHPRouter/RouterTest.php
@@ -45,6 +45,9 @@ class RouterTest extends PHPUnit_Framework_TestCase
             '_controller' => 'PHPRouter\Test\SomeController::user',
             'methods' => 'GET'
         )));
+        $route = new Route('/page/:page_id', array('_controller' => 'PHPRouter\Test\SomeController::page', 'methods' => 'GET' ));
+        $route->setFilters(['page_id' => '([a-zA-Z]+)'], true);
+        $collection->attachRoute($route);
         $collection->attachRoute(new Route('/', array(
             '_controller' => 'PHPRouter\Test\SomeController::indexAction',
             'methods' => 'GET'
@@ -63,6 +66,7 @@ class RouterTest extends PHPUnit_Framework_TestCase
             array($router, '/users', true),
             array($router, '/user/1', true),
             array($router, '/user/%E3%81%82', true),
+            array($router, '/page/MySuperPage', true),
         );
     }
 
@@ -77,12 +81,14 @@ class RouterTest extends PHPUnit_Framework_TestCase
             array($router, '/users', false),
             array($router, '/user/1', false),
             array($router, '/user/%E3%81%82', false),
+            array($router, '/page/MySuperPage', false),
 
             array($router, '/api', true),
             array($router, '/api/aaa', false),
             array($router, '/api/users', true),
             array($router, '/api/user/1', true),
             array($router, '/api/user/%E3%81%82', true),
+            array($router, '/api/page/MySuperPage', true),
         );
     }
 


### PR DESCRIPTION
Parameters by name add simple way to get named parameters into the controller method.
This optionnal argument, set to false by default, is available from setFilters method and can be used individually for each route.

Route :
```PHP
$route = new Route('/:page_id',     ['_controller' => 'someController::myMethod', 'methods' => 'GET' ]);
$route->setFilters([':page_id' => '([a-zA-Z]+)'], true);
```

Controller :
```PHP
class someController
{
  public function myMethod() {
    var_dump(func_get_args());
    // display : array(1) { [0]=> array(1) { ["page_id"]=> string(5) "mySuperPage" } }
  }
}
```

This feature makes sense when applied many filters.