### PR TITLE
Added shouldDispatchCallback

### DIFF
--- a/src/Router.php
+++ b/src/Router.php
@@ -45,6 +45,13 @@ class Router
     private $basePath = '';
 
     /**
+     * Callback called before dispatch. Should return the route to dispatch. 
+     * The choosen route for dispatch is the only parameter. 
+     * @var callable
+     */
+    private static $shouldDispatchCallback = null;
+
+    /**
      * @param RouteCollection $collection
      */
     public function __construct(RouteCollection $collection)
@@ -140,6 +147,17 @@ class Router
             }
 
             $routes->setParameters($params);
+
+            $shouldDispatchCallback = static::$shouldDispatchCallback;
+            //If shouldDispatch callback set, call it before dispatch
+            if($shouldDispatchCallback !== null){
+                $routes = $shouldDispatchCallback($routes);
+                //if false, ignore the route
+                if(!$routes){
+                    continue;
+                }
+            }
+
             $routes->dispatch();
 
             return $routes;
@@ -208,5 +226,16 @@ class Router
         }
 
         return $router;
+    }
+    
+    /**
+     * Sets a callback before dispatch to allow routing or not.
+     * The callable takes the dispatching route as first parameter.
+     * It should return false to skip the route, or a Route in replacement of the passed Route.
+     * @param callable $shouldDispatchCallback
+     * @return Router
+     */
+    public static function setShouldDispatchCallback(callable $shouldDispatchCallback){
+        static::$shouldDispatchCallback = $shouldDispatchCallback;
     }
 }

--- a/src/Router.php
+++ b/src/Router.php
@@ -233,7 +233,6 @@ class Router
      * The callable takes the dispatching route as first parameter.
      * It should return false to skip the route, or a Route in replacement of the passed Route.
      * @param callable $shouldDispatchCallback
-     * @return Router
      */
     public static function setShouldDispatchCallback(callable $shouldDispatchCallback){
         static::$shouldDispatchCallback = $shouldDispatchCallback;


### PR DESCRIPTION
It is a very simple and naive implementation actually not PSR-15 compliant, but maybe it is a good start for PSR-15 compliance.

The idea is to set a callback before dispatching the route, with these rules :
- The callback take one parameter which is the Route to be dispatched 
- if the callback returns false or equivalent, the route is ignored and the router continues to check other routes.
- if the callback returns a route, it is dispatched. So you can simply return the route to allow it, or generate a new Route in replacement (like an Error route for example).  


