### PR TITLE
Fixed hyphen position in regex

### DIFF
--- a/src/Route.php
+++ b/src/Route.php
@@ -153,7 +153,7 @@ class Route
             return $this->filters[$matches[1]];
         }
 
-        return '([\w-%]+)';
+        return '([\w%-]+)';
     }
 
     public function getParameters()

--- a/src/Router.php
+++ b/src/Router.php
@@ -121,7 +121,7 @@ class Router
 
             $params = array();
 
-            if (preg_match_all('/:([\w-%]+)/', $routes->getUrl(), $argument_keys)) {
+            if (preg_match_all('/:([\w%-]+)/', $routes->getUrl(), $argument_keys)) {
                 // grab array with matches
                 $argument_keys = $argument_keys[1];
 


### PR DESCRIPTION
PHP 5.5+ requires the hyphen to be escaped or moved to the end of
the list to match it as a literal hyphen